### PR TITLE
Vectorized and removed some calls to Uncertainties

### DIFF
--- a/Programs:Coding/ErrorAnalysis.py
+++ b/Programs:Coding/ErrorAnalysis.py
@@ -9,10 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from uncertainties import unumpy
 import pandas as pd
-from astropy import units as u
 from astropy.cosmology import Planck15 as p15
-import astropy.constants as const
-from scipy.interpolate import UnivariateSpline
 
 c = 3 * 10 ** 5
 
@@ -48,45 +45,18 @@ mjd = (final_list.loc[:, 'MJD'].values)
 fiberid = (final_list.loc[:, 'Fiber ID'].values)
 plate = (final_list.loc[:, 'Plate'].values)
 
-#We are also going to assume that a,b have 0 uncertainty (although unlikely)
-
-def gaussian(x, m, sigma, k):
-        sigma = (sigma / c) * m
-        g = k.reshape(Q, 1) * unumpy.exp(-.5 * ((x * np.ones((Q, len(x))) - m.reshape(Q, 1)) / sigma.reshape(Q,1))**2)
-        return g
-
-def gaussian3(x, unp_array):
-        m, sigma1, k1, sigma2, k2, sigma3, k3 = unp_array
-        gauss = gaussian(x, m, sigma1, k1) + gaussian(x, m, sigma2, k2) + gaussian(x, m, sigma3, k3)
-        return gauss
-
-def Gaussian(x, uarray):
-        m, sigma, k = uarray
-        sigma = (sigma / c) * m
-        g = k.reshape(Q, 1) * unumpy.exp(-.5 * ((x * np.ones((Q, len(x))) - m.reshape(Q, 1)) / sigma.reshape(Q,1))**2)
-        return g
-
 C4_wav = np.linspace(1500, 1600, 1000)
 Mg_wav = np.linspace(2750, 2850, 1000)
-unp_array = unumpy.uarray([mu, sig1, c4k1, sig2, c4k2, sig3, c4k3],
-                         [mu_err, sig1_err, c4k1_err, sig2_err, c4k2_err, sig3_err, c4k3_err])
-uarray = unumpy.uarray([mu_mg, mg_sig, mg_k], [mu_mg_er, mg_sig_er, mg_k_er])
-
-C4_flux = gaussian3(C4_wav, unp_array)
-Mg_flux = Gaussian(Mg_wav, uarray)
 d = p15.luminosity_distance(redshift).to('cm').value
 
-def FWHM(x, y):
-    y_new = y - y.min()
-    spline = UnivariateSpline(x, y_new - y_new.max() / 2, s = 0)
-    try:
-        a, b = spline.roots()
-    except:
-        return np.nan
-    return abs(a - b)
+def FWHM(x, y, center):
+    y_hm = y - y.max(axis=1)/2
+    hm_ix = abs(y - y_hm).argmin(axis=1)
+    fwhm = 2*abs(center - x[hm_ix])
+    return A_to_kms(fwhm, center)
 
 def A_to_kms(fwhm, m):
-    return const.c * fwhm / m
+    return c * fwhm / m
 
 def line_luminosity(wav, flux, dist):
     lum = 1e-17 * 4 * np.pi * dist**2 * flux
@@ -129,42 +99,33 @@ for j in range(len(final_list)):
         g = gauss(x, mu_new, sig1_new, c4k1_new) + gauss(x, mu_new, sig2_new, c4k2_new) + gauss(x, mu_new, sig3_new, c4k3_new)
         return g
 
-    civ_flux_varied = [gauss3(C4_wav, mu_new[i], sig1_new[i], sig2_new[i], sig3_new[i],
-                c4k1_new[i], c4k2_new[i], c4k3_new[i]) for i in range(1000)]
-    mgii_flux_varied = [gauss(Mg_wav, mg_mu_new[u], mg_sig_new[u], mg_k_new[u]) for u in range(1000)]
+    civ_flux_varied = gauss3(np.vstack(C4_wav), mu_new, sig1_new, sig2_new, sig3_new, c4k1_new, c4k2_new, c4k3_new)
+    mgii_flux_varied = gauss(np.vstack(Mg_wav), mg_mu_new, mg_sig_new, mg_k_new)
 
     # Luminosity
     civ_cont_param1 = np.random.normal(loc = 7.66, scale = 0.41, size = 1000)
     civ_cont_param2 = np.random.normal(loc = 0.863, scale = 0.009, size = 1000)
-    civ_lum_varied = [cont_luminosity(C4_wav, x, d[j], civ_cont_param1[i], civ_cont_param2[i]) for i, x in enumerate(civ_flux_varied)]
+    civ_lum_varied = cont_luminosity(C4_wav, civ_flux_varied, d[j], civ_cont_param1, civ_cont_param2)
     civ_mean_lum.append(np.nanmean(civ_lum_varied))
     civ_std_lum.append(np.nanstd(civ_lum_varied))
 
     mgii_cont_param1 = np.random.normal(loc = 1.22, scale = 0.11, size = 1000)
     mgii_cont_param2 = np.random.normal(loc = 1.016, scale = 0.003, size = 1000)
-    mgii_lum_varied = [cont_luminosity(Mg_wav, y, d[j], mgii_cont_param1[i], mgii_cont_param2[i]) for i, y in enumerate(mgii_flux_varied)]
+    mgii_lum_varied = cont_luminosity(Mg_wav, mgii_flux_varied, d[j], mgii_cont_param1, mgii_cont_param2)
     mgii_mean_lum.append(np.nanmean(mgii_lum_varied))
     mgii_std_lum.append(np.nanstd(mgii_lum_varied))
 
     # FWHM
-    fwhm_new = [FWHM(C4_wav, x) for x in civ_flux_varied] #fwhm err
-    fwhm_mg = [FWHM(Mg_wav, y) for y in mgii_flux_varied]
-    fwhm_mg_std = np.nanstd(fwhm_mg)
-    fwhm_mg_mean = np.nanmean(fwhm_mg)
-    fwhm_err_std = np.nanstd(fwhm_new)
-    fwhm_err_mean = np.nanmean(fwhm_new)
+    fwhm_new = FWHM(C4_wav, civ_flux_varied, mu_new) #fwhm err
+    fwhm_mg = FWHM(Mg_wav, mgii_flux_varied, mg_mu_new)
 
-   
-    fwhm_final_mean = A_to_kms(fwhm_err_mean * u.Angstrom, mu[j] * u.Angstrom).to('km/s').value
-    fwhm_final_std = A_to_kms(fwhm_err_std * u.Angstrom, mu[j] * u.Angstrom).to('km/s').value #you want to make a list of this for each quasar
-    #convert these into a unumpy for uncertainties
-    
-    fwhm_final_mean_mg = A_to_kms(fwhm_mg_mean * u.Angstrom, mu_mg[j] * u.Angstrom).to('km/s').value
-    fwhm_final_std_mg = A_to_kms(fwhm_mg_std * u.Angstrom, mu_mg[j] * u.Angstrom).to('km/s').value
-    
+    fwhm_final_mean = np.nanmean(fwhm_new)
+    fwhm_final_std = np.nanstd(fwhm_new)
+    fwhm_final_mean_mg = np.nanmean(fwhm_mg)
+    fwhm_final_std_mg = np.nanstd(fwhm_mg)
+
     mean_list.append(fwhm_final_mean)
     std_list.append(fwhm_final_std)
-    
     mg_mean_list.append(fwhm_final_mean_mg)
     mg_std_list.append(fwhm_final_std_mg)
 


### PR DESCRIPTION
Vectorized some calculations within the Monte Carlo loop, which required some changes to how FWHM is calculated. Tracked down the biggest source of memory errors to a few lines of code, such as

`unp_array = unumpy.uarray([mu, sig1, c4k1, sig2, c4k2, sig3, c4k3],
                         [mu_err, sig1_err, c4k1_err, sig2_err, c4k2_err, sig3_err, c4k3_err])`
which ended up being unnecessary. The uncertainties package appears not to like N-dimensional input, and it ended up eating up all available memory. Removed the extra code and it runs very quickly (< 5 hours it looks like).